### PR TITLE
Certificate store lookup filtering

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,6 +78,9 @@ changelog:
     - title: 'Bug fixes'
       regexp: "^.*fix[(\\w)]*:+.*$"
       order: 200
+    - title: 'Breaking Changes'
+      regexp: "^.*break[(\\w)]*:+.*$"
+      order: 1
     - title: 'Documentation updates'
       regexp: "^.*docs[(\\w)]*:+.*$"
       order: 400

--- a/api/certificate.go
+++ b/api/certificate.go
@@ -405,16 +405,22 @@ func (c *Client) ListCertificates(q map[string]string) ([]GetCertificateResponse
 	query.Query = append(query.Query, StringTuple{
 		"includeLocations", "true",
 	})
-	searchCollection, ok := q["collection"]
-	if ok {
+	searchCollection, cOk := q["collection"]
+	if cOk {
 		query.Query = append(query.Query, StringTuple{
 			"collectionId", searchCollection,
 		})
 	}
-	subjectName, ok := q["subject"]
-	if ok {
+	subjectName, sOk := q["subject"]
+	if sOk {
 		query.Query = append(query.Query, StringTuple{
 			"pq.queryString", fmt.Sprintf(`IssuedCN -eq "%s"`, subjectName),
+		})
+	}
+	tp, tpOk := q["thumbprint"]
+	if tpOk {
+		query.Query = append(query.Query, StringTuple{
+			"pq.queryString", fmt.Sprintf(`Thumbprint -eq "%s"`, tp),
 		})
 	}
 
@@ -424,6 +430,12 @@ func (c *Client) ListCertificates(q map[string]string) ([]GetCertificateResponse
 		Headers:  headers,
 		Query:    &query,
 		Payload:  nil,
+	}
+
+	cid, cidOk := q["id"]
+	if cidOk {
+		keyfactorAPIStruct.Endpoint = fmt.Sprintf("Certificates/%s", cid)
+		keyfactorAPIStruct.Query = nil
 	}
 
 	resp, err := c.sendRequest(keyfactorAPIStruct)

--- a/api/store.go
+++ b/api/store.go
@@ -154,7 +154,7 @@ func (c *Client) DeleteCertificateStore(storeId string) error {
 // ListCertificateStores takes no arguments and returns a slice of CertificateStore objects
 // that represent all certificate stores associated with a Keyfactor Command instance.
 
-func (c *Client) ListCertificateStores() (*[]GetCertificateStoreResponse, error) {
+func (c *Client) ListCertificateStores(params *map[string]interface{}) (*[]GetCertificateStoreResponse, error) {
 	// Set Keyfactor-specific headers
 	headers := &apiHeaders{
 		Headers: []StringTuple{
@@ -163,12 +163,29 @@ func (c *Client) ListCertificateStores() (*[]GetCertificateStoreResponse, error)
 		},
 	}
 
+	query := apiQuery{
+		Query: []StringTuple{},
+	}
+	if params != nil {
+		sId, ok := (*params)["Id"]
+		if ok {
+			var resp, err = c.GetCertificateStoreByID(fmt.Sprintf("%s", sId.([]string)[0]))
+			if err != nil {
+				return nil, err
+			}
+			return &[]GetCertificateStoreResponse{*resp}, nil
+		}
+
+		query, _ = buildQuery(*params, "certificateStoreQuery.queryString")
+	}
+
 	endpoint := "CertificateStores/"
 	keyfactorAPIStruct := &request{
 		Method:   "GET",
 		Endpoint: endpoint,
 		Headers:  headers,
 		Payload:  nil,
+		Query:    &query,
 	}
 
 	resp, err := c.sendRequest(keyfactorAPIStruct)


### PR DESCRIPTION
fix(api): Allow for certificate lookup by ID or thumbprint.
feat(helper): Added `buildQuery` to be used to easily build query params for API requests.
break(api): `client.ListCertificateStores()` now requires a parameter of a map of API query parameters.