### PR TITLE
v1.3.2 Patch

### DIFF
--- a/api/certificate.go
+++ b/api/certificate.go
@@ -241,7 +241,7 @@ func (c *Client) RevokeCert(rvargs *RevokeCertArgs) error {
 		return errors.New("invalid or nonexistent values required for certificate revocation")
 	}
 
-	if rvargs.EffectiveDate == "" {
+	if rvargs.EffectiveDate == "" || rvargs.EffectiveDate == "{null}" || rvargs.EffectiveDate == "null" {
 		rvargs.EffectiveDate = getTimestamp()
 	}
 

--- a/api/security.go
+++ b/api/security.go
@@ -111,7 +111,7 @@ func (c *Client) DeleteSecurityIdentity(id int) error {
 	return nil
 }
 
-func (c *Client) GetSecurityRoles() ([]GetSecurityRolesResponse, error) {
+func (c *Client) GetSecurityRoles() (GetSecurityRolesResponse, error) {
 	log.Println("[INFO] Getting list of Keyfactor security roles")
 
 	// Set Keyfactor-specific headers
@@ -134,7 +134,7 @@ func (c *Client) GetSecurityRoles() ([]GetSecurityRolesResponse, error) {
 		return nil, err
 	}
 
-	var jsonResp []GetSecurityRolesResponse
+	var jsonResp GetSecurityRolesResponse
 	err = json.NewDecoder(resp.Body).Decode(&jsonResp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a patch to v1.3.2 which enables the exporting of security roles on KFUtil. This patch includes the fix for GetSecurityRoles, which is needed for correct KFUtil functionality, and the fix belonging to the original v1.3.3.