### PR TITLE
Fix cert and security role bugs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
-          args: release --rm-dist
+          args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/api/security.go
+++ b/api/security.go
@@ -111,7 +111,7 @@ func (c *Client) DeleteSecurityIdentity(id int) error {
 	return nil
 }
 
-func (c *Client) GetSecurityRoles() ([]GetSecurityRolesResponse, error) {
+func (c *Client) GetSecurityRoles() (GetSecurityRolesResponse, error) {
 	log.Println("[INFO] Getting list of Keyfactor security roles")
 
 	// Set Keyfactor-specific headers
@@ -134,7 +134,7 @@ func (c *Client) GetSecurityRoles() ([]GetSecurityRolesResponse, error) {
 		return nil, err
 	}
 
-	var jsonResp []GetSecurityRolesResponse
+	var jsonResp GetSecurityRolesResponse
 	err = json.NewDecoder(resp.Body).Decode(&jsonResp)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Keyfactor/keyfactor-go-client
 go 1.18
 
 require (
+	github.com/Keyfactor/keyfactor-go-client-sdk v1.0.1
 	github.com/spbsoluble/go-pkcs12 v0.3.1
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Keyfactor/keyfactor-go-client-sdk v1.0.0 h1:/Q9F5+8xh5fHT1Wp78PCsoy0QwBcQwS7GT6tvYS434A=
+github.com/Keyfactor/keyfactor-go-client-sdk v1.0.0/go.mod h1:Z5pSk8YFGXHbKeQ1wTzVN8A4P/fZmtAwqu3NgBHbDOs=
 github.com/spbsoluble/go-pkcs12 v0.3.1 h1:3DWrjdP3HOeYW6aTUSO9pqqAgRL8VKZLqvD5PGkLVMo=
 github.com/spbsoluble/go-pkcs12 v0.3.1/go.mod h1:MX7DY37hx8xHKEMuJ16EMaVT8sT+4KPqK4gTTLFGcH0=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak=


### PR DESCRIPTION
fix(certs): Shadowed `ra` in delete renamed to `rvargs`.
fix(security): GetSecurityRoles returns a single `GetSecurityRolesResponse` which is already an array of roles.