### PR TITLE
Expand PAM models

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+
 	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
@@ -12,7 +13,7 @@ func (c *Client) GetAgentList() ([]Agent, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.AgentApi.AgentGetAgents(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -49,7 +50,7 @@ func (c *Client) GetAgent(id string) ([]Agent, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.AgentApi.AgentGetAgentDetail(context.Background(), id).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -85,7 +86,7 @@ func (c *Client) ApproveAgent(id string) (string, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	var ids = []string{id}
@@ -108,7 +109,7 @@ func (c *Client) DisApproveAgent(id string) (string, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	var ids = []string{id}
@@ -131,7 +132,7 @@ func (c *Client) ResetAgent(id string) (string, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, err := apiClient.AgentApi.AgentReset1(context.Background(), id).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -152,7 +153,7 @@ func (c *Client) FetchAgentLogs(id string) (string, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, err := apiClient.AgentApi.AgentFetchLogs(context.Background(), id).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()

--- a/api/ca.go
+++ b/api/ca.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
@@ -12,7 +13,7 @@ func (c *Client) GetCAList() ([]CA, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.CertificateAuthorityApi.CertificateAuthorityGetCas(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()

--- a/api/metadata.go
+++ b/api/metadata.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 	"net/http"
+
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
 // UpdateMetadata takes arguments for UpdateMetadataArgs to facilitate the
@@ -58,7 +59,7 @@ func (c *Client) UpdateMetadata(um *UpdateMetadataArgs) error {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, err := apiClient.CertificateApi.CertificateUpdateMetadata(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).MetadataUpdate(newReq).CollectionId(int32(um.CollectionId)).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -78,7 +79,7 @@ func (c *Client) GetAllMetadataFields() ([]MetadataField, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.MetadataFieldApi.MetadataFieldGetAllMetadataFields(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()

--- a/api/security.go
+++ b/api/security.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 	"log"
 	"net/http"
+
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
 // GetSecurityIdentities hits the /Security/Identities endpoint with a GET request and returns a list of
@@ -91,7 +92,7 @@ func (c *Client) DeleteSecurityIdentity(id int) error {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	_, httpResp, err := apiClient.SecurityApi.SecurityIdentityPermissions(context.Background(), int32(id)).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -220,7 +221,7 @@ func (c *Client) DeleteSecurityRole(id int) error {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, err := apiClient.SecurityRolesApi.SecurityRolesDeleteSecurityRole(context.Background(), int32(id)).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()

--- a/api/store.go
+++ b/api/store.go
@@ -133,7 +133,7 @@ func (c *Client) DeleteCertificateStore(storeId string) error {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, err := apiClient.CertificateStoreApi.CertificateStoreDeleteCertificateStore(context.Background(), storeId).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -298,7 +298,7 @@ func (c *Client) AddCertificateToStores(config *AddCertificateToStore) ([]string
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	newCollectionId := int32(config.CollectionId)
@@ -352,7 +352,7 @@ func (c *Client) RemoveCertificateFromStores(config *RemoveCertificateFromStore)
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	newCollectionId := int32(config.CollectionId)
@@ -389,7 +389,7 @@ func (c *Client) GetCertStoreInventory(storeId string) (*[]CertStoreInventory, e
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.CertificateStoreApi.CertificateStoreGetCertificateStoreInventory(context.Background(), storeId).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()

--- a/api/store.go
+++ b/api/store.go
@@ -505,15 +505,15 @@ func validateUpdateStoreArgs(ca *UpdateStoreFctArgs) error {
 
 // buildPropertiesInterface takes argument for an array of StringTuple and returns an interface of the associated values
 // in map[string]interface{} elements.
-func buildPropertiesInterface(properties map[string]string) interface{} {
+func buildPropertiesInterface(properties map[string]interface{}) interface{} {
 	// Create temporary array of interfaces
 	// When updating a property in Keyfactor, API expects {"key": {"value": "key-value"}} - Build this interface
 	propertiesInterface := make(map[string]interface{})
 
 	for key, value := range properties {
 		inside := make(map[string]interface{}) // Create {"value": "<key-value>"} interface
-		inside["value"] = value
-		propertiesInterface[key] = inside // Create {"<key>": {"value": "key-value"}} interface
+		inside["value"] = value                // TODO: put plain string if not an interface
+		propertiesInterface[key] = inside      // Create {"<key>": {"value": "key-value"}} interface
 	}
 
 	return propertiesInterface

--- a/api/store.go
+++ b/api/store.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
 // CreateStore takes arguments for CreateStoreFctArgs to facilitate the creation

--- a/api/store.go
+++ b/api/store.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 	"log"
 	"net/http"
+
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
 // CreateStore takes arguments for CreateStoreFctArgs to facilitate the creation
@@ -153,7 +154,7 @@ func (c *Client) DeleteCertificateStore(storeId string) error {
 // that represent all certificate stores associated with a Keyfactor Command instance.
 
 // TODO?
-func (c *Client) ListCertificateStores() (*[]GetCertificateStoreResponse, error) {
+func (c *Client) ListCertificateStores(params *map[string]interface{}) (*[]GetCertificateStoreResponse, error) {
 	// Set Keyfactor-specific headers
 	headers := &apiHeaders{
 		Headers: []StringTuple{
@@ -164,6 +165,18 @@ func (c *Client) ListCertificateStores() (*[]GetCertificateStoreResponse, error)
 
 	query := apiQuery{
 		Query: []StringTuple{},
+	}
+	if params != nil {
+		sId, ok := (*params)["Id"]
+		if ok {
+			var resp, err = c.GetCertificateStoreByID(fmt.Sprintf("%s", sId.([]string)[0]))
+			if err != nil {
+				return nil, err
+			}
+			return &[]GetCertificateStoreResponse{*resp}, nil
+		}
+
+		query, _ = buildQuery(*params, "certificateStoreQuery.queryString")
 	}
 
 	endpoint := "CertificateStores/"

--- a/api/store.go
+++ b/api/store.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
-	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
 // CreateStore takes arguments for CreateStoreFctArgs to facilitate the creation
@@ -457,22 +455,22 @@ func (c *Client) GetCertStoreInventory(storeId string) (*[]CertStoreInventory, e
 }
 
 // unmarshalPropertiesString unmarshalls a JSON string and serializes it into an array of StringTuple.
-func unmarshalPropertiesString(properties string) map[string]string {
+func unmarshalPropertiesString(properties string) map[string]interface{} {
 	if properties != "" {
 		// First, unmarshal JSON properties string to []interface{}
 		var tempInterface interface{}
 		if err := json.Unmarshal([]byte(properties), &tempInterface); err != nil {
-			return make(map[string]string)
+			return make(map[string]interface{})
 		}
 		// Then, iterate through each key:value pair and serialize into map[string]string
-		newMap := make(map[string]string)
+		newMap := make(map[string]interface{})
 		for key, value := range tempInterface.(map[string]interface{}) {
-			newMap[key] = value.(string)
+			newMap[key] = value
 		}
 		return newMap
 	}
 
-	return make(map[string]string)
+	return make(map[string]interface{})
 }
 
 func validateCreateStoreArgs(ca *CreateStoreFctArgs) error {

--- a/api/store_container.go
+++ b/api/store_container.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 	"log"
 	"strconv"
+
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
 // GetStoreContainers returns a list of store containers
@@ -16,7 +17,7 @@ func (c *Client) GetStoreContainers() (*[]CertStoreContainer, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.CertificateStoreContainerApi.CertificateStoreContainerGetAllCertificateStoreContainers(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()

--- a/api/store_models.go
+++ b/api/store_models.go
@@ -13,14 +13,14 @@ type CreateStoreFctArgs struct {
 	// automatically populated by the CreateStore method. However, if configured, this field will be used.
 	PropertiesString string `json:"Properties,omitempty"`
 	// Mapped name-value pair field used to configure properties.
-	Properties            map[string]string    `json:"-"`
-	AgentId               string               `json:"AgentId"`
-	AgentAssigned         *bool                `json:"AgentAssigned,omitempty"`
-	ContainerName         *string              `json:"ContainerName,omitempty"`
-	InventorySchedule     *InventorySchedule   `json:"InventorySchedule,omitempty"`
-	ReEnrollmentStatus    *ReEnrollmnentConfig `json:"ReEnrollmentStatus,omitempty"`
-	SetNewPasswordAllowed *bool                `json:"SetNewPasswordAllowed,omitempty"`
-	Password              *StorePasswordConfig `json:"Password,omitempty"`
+	Properties            map[string]interface{} `json:"-"`
+	AgentId               string                 `json:"AgentId"`
+	AgentAssigned         *bool                  `json:"AgentAssigned,omitempty"`
+	ContainerName         *string                `json:"ContainerName,omitempty"`
+	InventorySchedule     *InventorySchedule     `json:"InventorySchedule,omitempty"`
+	ReEnrollmentStatus    *ReEnrollmnentConfig   `json:"ReEnrollmentStatus,omitempty"`
+	SetNewPasswordAllowed *bool                  `json:"SetNewPasswordAllowed,omitempty"`
+	Password              *StorePasswordConfig   `json:"Password,omitempty"`
 }
 
 // UpdateStoreFctArgs holds the function arguments used for calling the UpdateStore method.
@@ -62,33 +62,50 @@ type ReEnrollmnentConfig struct {
 }
 
 // StorePasswordConfig configures the password field for a new certificate store.
+// USED FOR GETTING SECRET TYPE FIELDS
 type StorePasswordConfig struct {
-	Value          *string `json:"Value"`
-	SecretTypeGuid *string `json:"SecretTypeGuid,omitempty"`
-	InstanceId     *string `json:"InstanceId,omitempty"`
-} // ProviderTypeParameterValues - Not yet implemented
-// ProviderTypeParameterValues ProviderTypeParams - Not implemented
+	Value                       *string                    `json:"Value"`
+	SecretTypeGuid              *string                    `json:"SecretTypeGuid"`
+	InstanceId                  *string                    `json:"InstanceId"`
+	InstanceGuid                *string                    `json:"InstanceGuid"`
+	ProviderTypeParameterValues *[]ProviderTypeParamValues `json:"ProviderTypeParameterValues"`
+	ProviderId                  *string                    `json:"ProviderId"`
+	IsManaged                   bool                       `json:"IsManaged"`
+}
 
 /* Future non-critical functionality */
 
+type ProviderTypeParamValues struct {
+	Id                 *string             `json:"Id"`
+	Value              *string             `json:"Value"`
+	InstanceId         *string             `json:InstanceId"`
+	InstanceGuid       *string             `json:InstanceGuid"`
+	ProviderTypeParams *ProviderTypeParams `json:"ProviderTypeParams"`
+	// Provider     ProviderParams
+}
+
 type ProviderTypeParams struct {
-	Id           string
-	Value        string
-	InstanceId   string
-	InstanceGuid string
-	Provider     ProviderParams
+	Id            *string `json:"Id"`
+	Name          *string `json:"Name`
+	DisplayName   *string `json:"DisplayName`
+	DataType      *int    `json:"DataType"`
+	InstanceLevel bool    `json:"InstanceLevel`
+	// ProviderType
 }
 
-type ProviderParams struct {
-	Id           int
-	Name         string
-	Area         int
-	ProviderType ProviderType
+// Used to post regular secret-type fields
+type SecretField struct {
+	SecretValue string `json:"SecretValue`
 }
 
-type ProviderType struct {
-	Id   string
-	Name string
+// Used to post PAM-type secret fields
+type PAMField struct {
+	// this interface should be a json object
+	// key is the parameter name
+	// value is the parameter value
+	Parameters interface{} `json:"Parameters"`
+	// Provider int id
+	Provider string `json:Provider"`
 }
 
 // CertStoreTypeResponse contains the response elements returned from the GetCertificateStoreType method.

--- a/api/store_models.go
+++ b/api/store_models.go
@@ -20,7 +20,7 @@ type CreateStoreFctArgs struct {
 	InventorySchedule     *InventorySchedule     `json:"InventorySchedule,omitempty"`
 	ReEnrollmentStatus    *ReEnrollmnentConfig   `json:"ReEnrollmentStatus,omitempty"`
 	SetNewPasswordAllowed *bool                  `json:"SetNewPasswordAllowed,omitempty"`
-	Password              *StorePasswordConfig   `json:"Password,omitempty"`
+	Password              *interface{}           `json:"Password,omitempty"` // type: api.StorePasswordConfig
 }
 
 // UpdateStoreFctArgs holds the function arguments used for calling the UpdateStore method.
@@ -64,28 +64,28 @@ type ReEnrollmnentConfig struct {
 // StorePasswordConfig configures the password field for a new certificate store.
 // USED FOR GETTING SECRET TYPE FIELDS
 type StorePasswordConfig struct {
-	Value                       *string                    `json:"Value"`
+	Value                       string                     `json:"Value"`
 	SecretTypeGuid              *string                    `json:"SecretTypeGuid"`
 	InstanceId                  *string                    `json:"InstanceId"`
 	InstanceGuid                *string                    `json:"InstanceGuid"`
 	ProviderTypeParameterValues *[]ProviderTypeParamValues `json:"ProviderTypeParameterValues"`
-	ProviderId                  *string                    `json:"ProviderId"`
+	ProviderId                  *int                       `json:"ProviderId"`
 	IsManaged                   bool                       `json:"IsManaged"`
 }
 
 /* Future non-critical functionality */
 
 type ProviderTypeParamValues struct {
-	Id                 *string             `json:"Id"`
-	Value              *string             `json:"Value"`
-	InstanceId         *string             `json:InstanceId"`
-	InstanceGuid       *string             `json:InstanceGuid"`
-	ProviderTypeParams *ProviderTypeParams `json:"ProviderTypeParams"`
+	Id                *int                `json:"Id"`
+	Value             *string             `json:"Value"`
+	InstanceId        *string             `json:InstanceId"`
+	InstanceGuid      *string             `json:InstanceGuid"`
+	ProviderTypeParam *ProviderTypeParams `json:"ProviderTypeParam"`
 	// Provider     ProviderParams
 }
 
 type ProviderTypeParams struct {
-	Id            *string `json:"Id"`
+	Id            *int    `json:"Id"`
 	Name          *string `json:"Name`
 	DisplayName   *string `json:"DisplayName`
 	DataType      *int    `json:"DataType"`
@@ -145,23 +145,23 @@ type CertStoreTypeResponse struct {
 }
 
 type GetCertificateStoreResponse struct {
-	Id                      string              `json:"Id,omitempty"`
-	ContainerId             int                 `json:"ContainerId,omitempty"`
-	ClientMachine           string              `json:"ClientMachine,omitempty"`
-	StorePath               string              `json:"Storepath,omitempty"`
-	CertStoreInventoryJobId string              `json:"CertStoreInventoryJobId,omitempty"`
-	CertStoreType           int                 `json:"CertStoreType,omitempty"`
-	Approved                bool                `json:"Approved,omitempty"`
-	CreateIfMissing         bool                `json:"CreateIfMissing,omitempty"`
-	PropertiesString        string              `json:"Properties,omitempty"`
-	Properties              map[string]string   `json:"-"`
-	AgentId                 string              `json:"AgentId,omitempty"`
-	AgentAssigned           bool                `json:"AgentAssigned,omitempty"`
-	ContainerName           string              `json:"ContainerName,omitempty"`
-	InventorySchedule       InventorySchedule   `json:"InventorySchedule"`
-	ReenrollmentStatus      ReEnrollmnentConfig `json:"ReenrollmentStatus,omitempty"`
-	SetNewPasswordAllowed   bool                `json:"SetNewPasswordAllowed,omitempty"`
-	Password                StorePasswordConfig `json:"Password,omitempty"`
+	Id                      string                 `json:"Id,omitempty"`
+	ContainerId             int                    `json:"ContainerId,omitempty"`
+	ClientMachine           string                 `json:"ClientMachine,omitempty"`
+	StorePath               string                 `json:"Storepath,omitempty"`
+	CertStoreInventoryJobId string                 `json:"CertStoreInventoryJobId,omitempty"`
+	CertStoreType           int                    `json:"CertStoreType,omitempty"`
+	Approved                bool                   `json:"Approved,omitempty"`
+	CreateIfMissing         bool                   `json:"CreateIfMissing,omitempty"`
+	PropertiesString        string                 `json:"Properties,omitempty"`
+	Properties              map[string]interface{} `json:"-"`
+	AgentId                 string                 `json:"AgentId,omitempty"`
+	AgentAssigned           bool                   `json:"AgentAssigned,omitempty"`
+	ContainerName           string                 `json:"ContainerName,omitempty"`
+	InventorySchedule       InventorySchedule      `json:"InventorySchedule"`
+	ReenrollmentStatus      ReEnrollmnentConfig    `json:"ReenrollmentStatus,omitempty"`
+	SetNewPasswordAllowed   bool                   `json:"SetNewPasswordAllowed,omitempty"`
+	Password                StorePasswordConfig    `json:"Password,omitempty"`
 }
 
 // PropertyDefinition defines property fields associated with a certificate store type, and is returned by the

--- a/api/store_type.go
+++ b/api/store_type.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 	"log"
+
+	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
 //type StringInt int32
@@ -63,7 +64,7 @@ func (c *Client) GetCertificateStoreTypeByName(name string) (*CertificateStoreTy
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.CertificateStoreTypeApi.CertificateStoreTypeGetCertificateStoreType1(context.Background(), name).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -94,7 +95,7 @@ func (c *Client) GetCertificateStoreTypeById(id int) (*CertificateStoreType, err
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.CertificateStoreTypeApi.CertificateStoreTypeGetCertificateStoreType0(context.Background(), int32(id)).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -117,7 +118,7 @@ func (c *Client) ListCertificateStoreTypes() (*[]CertificateStoreType, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.CertificateStoreTypeApi.CertificateStoreTypeGetTypes(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -151,7 +152,7 @@ func (c *Client) CreateStoreType(ca *CertificateStoreType) (*CertificateStoreTyp
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	var newReq keyfactor.KeyfactorApiModelsCertificateStoresTypesCertificateStoreTypeCreationRequest
@@ -186,7 +187,7 @@ func (c *Client) UpdateStoreType(ca *CertificateStoreType) (*CertificateStoreTyp
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	var newReq keyfactor.KeyfactorApiModelsCertificateStoresTypesCertificateStoreTypeUpdateRequest
@@ -215,7 +216,7 @@ func (c *Client) DeleteCertificateStoreType(id int) (*DeleteStoreType, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, err := apiClient.CertificateStoreTypeApi.CertificateStoreTypeDeleteCertificateStoreType(context.Background(), int32(id)).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()

--- a/api/template.go
+++ b/api/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+
 	"github.com/Keyfactor/keyfactor-go-client-sdk/api/keyfactor"
 )
 
@@ -18,7 +19,7 @@ func (c *Client) GetTemplate(Id interface{}) (*GetTemplateResponse, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	newId := Id.(int32)
@@ -44,7 +45,7 @@ func (c *Client) GetTemplates() ([]GetTemplateResponse, error) {
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	resp, _, err := apiClient.TemplateApi.TemplateGetTemplates(context.Background()).XKeyfactorRequestedWith(xKeyfactorRequestedWith).XKeyfactorApiVersion(xKeyfactorApiVersion).Execute()
@@ -73,7 +74,7 @@ func (c *Client) UpdateTemplate(uta *UpdateTemplateArg) (*UpdateTemplateResponse
 	xKeyfactorRequestedWith := "APIClient"
 	xKeyfactorApiVersion := "1"
 
-	configuration := keyfactor.NewConfiguration()
+	configuration := keyfactor.NewConfiguration(make(map[string]string))
 	apiClient := keyfactor.NewAPIClient(configuration)
 
 	var newReq keyfactor.ModelsTemplateUpdateRequest


### PR DESCRIPTION
Expands PAM Models for Cert Stores to support getting and posting PAM-types for secret fields.
Also restores some changes lost in a merge and calls method in sdk with correct arguments