### PR TITLE
fix(certificate): UnpackPEM selects leaf by topology, not position

### DIFF
--- a/v3/api/helpers.go
+++ b/v3/api/helpers.go
@@ -64,6 +64,7 @@ func UnpackPEM(pemData interface{}, password string) (
 	}
 
 	var certificates []string
+	var parsedCerts []*x509.Certificate
 	var encryptedKeyBlock *pem.Block
 
 	// Parse all PEM blocks
@@ -79,6 +80,13 @@ func UnpackPEM(pemData interface{}, password string) (
 		case "CERTIFICATE":
 			certPEM := string(pem.EncodeToMemory(block))
 			certificates = append(certificates, certPEM)
+			// Keep a parsed copy (index-aligned with certificates) so the leaf
+			// can be selected by chain topology rather than by position.
+			if c, parseErr := x509.ParseCertificate(block.Bytes); parseErr == nil && c != nil {
+				parsedCerts = append(parsedCerts, c)
+			} else {
+				parsedCerts = append(parsedCerts, nil)
+			}
 		case "ENCRYPTED PRIVATE KEY":
 			encryptedKeyBlock = block
 		case "RSA PRIVATE KEY", "EC PRIVATE KEY", "PRIVATE KEY":
@@ -97,11 +105,36 @@ func UnpackPEM(pemData interface{}, password string) (
 		privateKey = decryptedKey
 	}
 
-	// Assign certificates: first is leaf, rest are CA chain
+	// Select the leaf by chain topology, not position: Keyfactor Command may
+	// return the bundle in any order (notably root-first for externally-rooted
+	// chains such as DigiCert PKIaaS), so certificates[0] is not reliably the
+	// end-entity. findLeafCert picks the cert no other cert in the set issued,
+	// matching the behavior of DownloadCertificate. The remaining certs become
+	// the CA chain, preserving their original order.
 	if len(certificates) > 0 {
-		certificate = certificates[0]
-		if len(certificates) > 1 {
-			caCertificates = certificates[1:]
+		leafIdx := 0
+		// Collect the successfully-parsed certs for leaf detection.
+		var valid []*x509.Certificate
+		for _, c := range parsedCerts {
+			if c != nil {
+				valid = append(valid, c)
+			}
+		}
+		if leaf := findLeafCert(valid); leaf != nil {
+			for i, c := range parsedCerts {
+				if c != nil && c.Equal(leaf) {
+					leafIdx = i
+					break
+				}
+			}
+		}
+
+		certificate = certificates[leafIdx]
+		for i, certPEM := range certificates {
+			if i == leafIdx {
+				continue
+			}
+			caCertificates = append(caCertificates, certPEM)
 		}
 	}
 

--- a/v3/api/unpackpem_leaf_test.go
+++ b/v3/api/unpackpem_leaf_test.go
@@ -1,0 +1,165 @@
+package api
+
+// Regression tests for UnpackPEM leaf selection. UnpackPEM previously assumed
+// certificates[0] was the end-entity leaf, which returns the ROOT when Keyfactor
+// Command sends a non-leaf-first PEM bundle (e.g. externally-rooted chains
+// returned root-first). It now selects the leaf by chain topology via
+// findLeafCert, matching DownloadCertificate.
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func pemCert(c *x509.Certificate) string {
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.Raw}))
+}
+
+// makeTestIntermediateCA creates an intermediate CA signed by the given parent.
+func makeTestIntermediateCA(t *testing.T, parentKey *rsa.PrivateKey, parentCert *x509.Certificate) (*rsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate intermediate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(10),
+		Subject:               pkix.Name{CommonName: "Test Intermediate CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(5 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parentCert, &key.PublicKey, parentKey)
+	if err != nil {
+		t.Fatalf("create intermediate cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse intermediate cert: %v", err)
+	}
+	return key, cert
+}
+
+// assertUnpackLeaf runs UnpackPEM and asserts the selected leaf is the expected
+// end-entity (non-CA) cert and the CA chain has the expected length.
+func assertUnpackLeaf(t *testing.T, bundle, wantCN string, wantChainLen int) {
+	t.Helper()
+	_, certificate, caCerts, err := UnpackPEM(bundle, "")
+	if err != nil {
+		t.Fatalf("UnpackPEM: %v", err)
+	}
+	block, _ := pem.Decode([]byte(certificate))
+	if block == nil {
+		t.Fatalf("returned leaf is not a PEM block: %q", certificate)
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse returned leaf: %v", err)
+	}
+	if c.IsCA {
+		t.Errorf("UnpackPEM returned a CA as the leaf: CN=%q IsCA=true", c.Subject.CommonName)
+	}
+	if c.Subject.CommonName != wantCN {
+		t.Errorf("leaf CN = %q, want %q", c.Subject.CommonName, wantCN)
+	}
+	if len(caCerts) != wantChainLen {
+		t.Errorf("caCertificates length = %d, want %d", len(caCerts), wantChainLen)
+	}
+}
+
+// TestUnpackPEM_LeafSelection verifies the end-entity leaf is selected for every
+// bundle ordering, including the root-first orderings that fooled the old
+// positional certificates[0] logic.
+func TestUnpackPEM_LeafSelection(t *testing.T) {
+	rootKey, root := makeTestCA(t)
+	intKey, intermediate := makeTestIntermediateCA(t, rootKey, root)
+	leaf := makeTestLeaf(t, intKey, intermediate)
+
+	rootPEM := pemCert(root)
+	intPEM := pemCert(intermediate)
+	leafPEM := pemCert(leaf)
+
+	cases := []struct {
+		name     string
+		bundle   string
+		chainLen int
+	}{
+		{"root-first-3cert", rootPEM + intPEM + leafPEM, 2}, // the bug trigger
+		{"leaf-first-3cert", leafPEM + intPEM + rootPEM, 2},
+		{"shuffled-3cert", rootPEM + leafPEM + intPEM, 2},
+		{"root-first-2cert", rootPEM + leafPEM, 1}, // the bug trigger
+		{"leaf-first-2cert", leafPEM + rootPEM, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertUnpackLeaf(t, tc.bundle, "test-leaf.example.com", tc.chainLen)
+		})
+	}
+}
+
+// TestUnpackPEM_WithPrivateKey_RootFirst verifies that, with a private key block
+// present in a root-first bundle, both the key is extracted and the leaf (not the
+// root) is selected.
+func TestUnpackPEM_WithPrivateKey_RootFirst(t *testing.T) {
+	rootKey, root := makeTestCA(t)
+	leaf := makeTestLeaf(t, rootKey, root)
+
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(k)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}))
+
+	// key + ROOT-first certs
+	bundle := keyPEM + pemCert(root) + pemCert(leaf)
+
+	privateKey, certificate, caCerts, err := UnpackPEM(bundle, "")
+	if err != nil {
+		t.Fatalf("UnpackPEM: %v", err)
+	}
+	if privateKey == "" {
+		t.Error("expected private key to be extracted")
+	}
+	block, _ := pem.Decode([]byte(certificate))
+	if block == nil {
+		t.Fatalf("returned leaf is not a PEM block")
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse returned leaf: %v", err)
+	}
+	if c.IsCA || c.Subject.CommonName != "test-leaf.example.com" {
+		t.Errorf("leaf = CN=%q IsCA=%v, want test-leaf.example.com (non-CA)", c.Subject.CommonName, c.IsCA)
+	}
+	if len(caCerts) != 1 {
+		t.Errorf("caCertificates length = %d, want 1", len(caCerts))
+	}
+}
+
+// TestUnpackPEM_SingleCert returns the only cert as the leaf, no chain.
+func TestUnpackPEM_SingleCert(t *testing.T) {
+	rootKey, root := makeTestCA(t)
+	leaf := makeTestLeaf(t, rootKey, root)
+	_, certificate, caCerts, err := UnpackPEM(pemCert(leaf), "")
+	if err != nil {
+		t.Fatalf("UnpackPEM: %v", err)
+	}
+	if certificate == "" {
+		t.Fatal("expected a certificate")
+	}
+	if len(caCerts) != 0 {
+		t.Errorf("caCertificates length = %d, want 0", len(caCerts))
+	}
+}

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -77,6 +77,7 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/spbsoluble/go-pkcs12 v0.3.3 h1:3nh7IKn16RDpmrSMtOu1JvbB0XHYq1j+IsICdU1c7J4=
 github.com/spbsoluble/go-pkcs12 v0.3.3/go.mod h1:MAxKIUEIl/QVcua/I1L4Otyxl9UvLCCIktce2Tjz6Nw=
+github.com/spbsoluble/go-pkcs12 v0.4.0 h1:3HOVPZ8pvYqhAyz/NJzT9YODQJ3HbZvB9/CMVmvGaUM=
 github.com/spbsoluble/go-pkcs12 v0.4.0/go.mod h1:MAxKIUEIl/QVcua/I1L4Otyxl9UvLCCIktce2Tjz6Nw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=


### PR DESCRIPTION
## Summary

`UnpackPEM` selected the leaf certificate **positionally** — it assumed `certificates[0]` was the end-entity leaf:

```go
// before
certificate = certificates[0]
caCertificates = certificates[1:]
```

This returns the **root CA** as the leaf whenever Keyfactor Command sends a PEM bundle that is not leaf-first. Externally-rooted chains (e.g. DigiCert PKIaaS) are commonly returned **root-first**, so `certificates[0]` is the root. Consumers that trust the returned leaf (e.g. the Terraform provider populating `common_name` / `certificate_pem`) then persist the root CA's subject, forcing certificate replacement on every run.

## Fix

Select the leaf by chain topology using the package's existing `findLeafCert` (the cert no other cert in the set issued) — the same helper `DownloadCertificate` already uses for the P7B path. The remaining certs become the CA chain, preserving their original order. Falls back to index 0 when no certs parse, preserving prior behavior for degenerate inputs.

This makes leaf selection order-independent and consistent across the P7B and PEM code paths.

## Also included

- **go.sum:** added the missing `github.com/spbsoluble/go-pkcs12 v0.4.0` module zip checksum (`h1:`). `go.mod` pins v0.4.0 but `go.sum` only carried the `/go.mod` hash, so clean builds failed with `missing go.sum entry for module providing package github.com/spbsoluble/go-pkcs12`.

## Tests

New `v3/api/unpackpem_leaf_test.go`:
- `TestUnpackPEM_LeafSelection` — root-first / leaf-first / shuffled orderings, 2- and 3-cert chains; asserts the non-CA leaf is selected and the chain length is correct.
- `TestUnpackPEM_WithPrivateKey_RootFirst` — root-first bundle with a private key block; asserts both key extraction and correct leaf selection.
- `TestUnpackPEM_SingleCert` — single cert returned as leaf, empty chain.

Verified **red→green**: the root-first / shuffled cases fail against the pre-fix code (return `Test Root CA`) and pass after the fix. Full `./api/...` suite green.

Fixes #52
