### PR TITLE
fix(store): nullable bool flags, EntryPassword omitempty, paginate GetStoreContainers

### DIFF
--- a/v3/api/store_container.go
+++ b/v3/api/store_container.go
@@ -22,7 +22,15 @@ import (
 	"strconv"
 )
 
-// GetStoreContainers returns a list of store containers
+// getStoreContainersMaxPages is the maximum number of pages GetStoreContainers
+// will fetch before aborting with an error. It is an unexported package-level
+// var (not a const) so that tests can lower it without iterating thousands of
+// times.
+var getStoreContainersMaxPages = 10000
+
+// GetStoreContainers returns a list of store containers, paginating
+// automatically so that instances with more than the server's default page
+// size (100) return all containers.
 func (c *Client) GetStoreContainers() (*[]CertStoreContainer, error) {
 	log.Println("[INFO] Listing certificate store containers.")
 
@@ -33,24 +41,49 @@ func (c *Client) GetStoreContainers() (*[]CertStoreContainer, error) {
 		},
 	}
 
-	keyfactorAPIStruct := &request{
-		Method:   "GET",
-		Endpoint: "CertificateStoreContainers",
-		Headers:  headers,
-		Payload:  nil,
+	const pageSize = 100
+	var all []CertStoreContainer
+	var page int
+	for page = 1; page <= getStoreContainersMaxPages; page++ {
+		keyfactorAPIStruct := &request{
+			Method:   "GET",
+			Endpoint: "CertificateStoreContainers",
+			Headers:  headers,
+			Query: &apiQuery{
+				Query: []StringTuple{
+					{"PageReturned", strconv.Itoa(page)},
+					{"ReturnLimit", strconv.Itoa(pageSize)},
+				},
+			},
+			Payload: nil,
+		}
+
+		resp, err := c.sendRequest(keyfactorAPIStruct)
+		if err != nil {
+			log.Printf("[ERROR] GetStoreContainers: request for page %d failed: %s", page, err)
+			return nil, err
+		}
+
+		var pageResults []CertStoreContainer
+		decodeErr := json.NewDecoder(resp.Body).Decode(&pageResults)
+		resp.Body.Close()
+		if decodeErr != nil {
+			log.Printf("[ERROR] GetStoreContainers: failed to decode page %d: %s", page, decodeErr)
+			return nil, decodeErr
+		}
+
+		all = append(all, pageResults...)
+		if len(pageResults) == 0 || len(pageResults) < pageSize {
+			break
+		}
 	}
 
-	resp, err := c.sendRequest(keyfactorAPIStruct)
-	if err != nil {
-		return nil, err
+	if page > getStoreContainersMaxPages {
+		return nil, fmt.Errorf("GetStoreContainers: exceeded max pages (%d); server may be ignoring pagination", getStoreContainersMaxPages)
 	}
 
-	jsonResp := &[]CertStoreContainer{}
-	err = json.NewDecoder(resp.Body).Decode(&jsonResp)
-	if err != nil {
-		return nil, err
-	}
-	return jsonResp, nil
+	log.Printf("[INFO] Listed %d certificate store containers across %d page(s).", len(all), page)
+	return &all, nil
 }
 
 // GetStoreContainer takes an ID and returns a single store container

--- a/v3/api/store_container_test.go
+++ b/v3/api/store_container_test.go
@@ -1,0 +1,155 @@
+// Copyright 2024 Keyfactor
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+// TestGetStoreContainers_Pagination verifies that GetStoreContainers fetches
+// all pages. Before the fix, only the server's first page (default page size)
+// was returned; a container sorted beyond that first page would never be
+// found by ID via the list-endpoint fallback in the provider's
+// lookupContainerNameByID, causing the container name to silently read back
+// as null even though the container assignment itself was intact.
+func TestGetStoreContainers_Pagination(t *testing.T) {
+	const totalContainers = 150
+
+	allContainers := make([]CertStoreContainer, totalContainers)
+	for i := range allContainers {
+		id := i + 1
+		allContainers[i] = CertStoreContainer{
+			Id:   &id,
+			Name: "Container-" + strconv.Itoa(id),
+		}
+	}
+	// Place the known-problematic late-sorted container at index 118 (position 119, past a 100-item first page).
+	lateId := 999
+	allContainers[118] = CertStoreContainer{Id: &lateId, Name: "zzz-late-sorted-container"}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, _ := strconv.Atoi(r.URL.Query().Get("PageReturned"))
+		limit, _ := strconv.Atoi(r.URL.Query().Get("ReturnLimit"))
+		if page < 1 {
+			page = 1
+		}
+		if limit < 1 {
+			limit = 50
+		}
+		start := (page - 1) * limit
+		end := start + limit
+		if start >= len(allContainers) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]"))
+			return
+		}
+		if end > len(allContainers) {
+			end = len(allContainers)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(allContainers[start:end])
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+
+	containers, err := c.GetStoreContainers()
+	if err != nil {
+		t.Fatalf("GetStoreContainers() error: %v", err)
+	}
+	if containers == nil || len(*containers) != totalContainers {
+		got := 0
+		if containers != nil {
+			got = len(*containers)
+		}
+		t.Errorf("GetStoreContainers() returned %d containers, want %d (pagination broken)", got, totalContainers)
+	}
+
+	found := false
+	for _, container := range *containers {
+		if container.Name == "zzz-late-sorted-container" {
+			found = true
+			if container.Id == nil || *container.Id != lateId {
+				t.Errorf("target container Id = %v, want %d", container.Id, lateId)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("target container %q (position 119) not found — page 2+ results missing", "zzz-late-sorted-container")
+	}
+}
+
+// TestGetStoreContainers_MaxPagesGuard verifies that GetStoreContainers
+// aborts with an error when the server always returns a full page
+// (simulating a server that ignores pagination and would otherwise cause an
+// infinite loop / unbounded memory growth).
+func TestGetStoreContainers_MaxPagesGuard(t *testing.T) {
+	fullPage := make([]CertStoreContainer, 100)
+	for i := range fullPage {
+		id := i + 1
+		fullPage[i] = CertStoreContainer{Id: &id, Name: "Container-" + strconv.Itoa(id)}
+	}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always return a full page regardless of PageReturned — simulates a
+		// server that ignores paging parameters.
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(fullPage)
+	}))
+	defer srv.Close()
+
+	// Lower the safety bound so the test terminates quickly.
+	orig := getStoreContainersMaxPages
+	getStoreContainersMaxPages = 3
+	defer func() { getStoreContainersMaxPages = orig }()
+
+	c := newTestClient(srv)
+
+	_, err := c.GetStoreContainers()
+	if err == nil {
+		t.Fatal("GetStoreContainers() expected an error when max pages exceeded, got nil")
+	}
+}
+
+// TestGetStoreContainers_SinglePage verifies that a sub-pageSize result
+// terminates the pagination loop in a single call.
+func TestGetStoreContainers_SinglePage(t *testing.T) {
+	calls := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		id := 1
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]CertStoreContainer{{Id: &id, Name: "OnlyContainer"}})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+
+	containers, err := c.GetStoreContainers()
+	if err != nil {
+		t.Fatalf("GetStoreContainers() error: %v", err)
+	}
+	if containers == nil || len(*containers) != 1 {
+		t.Errorf("got %v containers, want 1", containers)
+	}
+	if calls != 1 {
+		t.Errorf("server called %d times, want 1", calls)
+	}
+}

--- a/v3/api/store_models.go
+++ b/v3/api/store_models.go
@@ -294,7 +294,9 @@ type CertificateStore struct {
 	Overwrite bool `json:"Overwrite,omitempty"`
 
 	// The password to set on the entry within the certificate store, if applicable. Only select certificate stores support entry passwords (e.g. Java keystores).
-	EntryPassword *EntryPassword `json:"EntryPassword"`
+	// omitempty: a nil pointer must be omitted, not marshaled as an explicit
+	// "EntryPassword": null on every add-certificate-to-store request.
+	EntryPassword *EntryPassword `json:"EntryPassword,omitempty"`
 
 	// Password used to secure certificate store, if it exists as a PKCS#12
 	PfxPassword string `json:"PfxPassword,omitempty"`

--- a/v3/api/store_type_models.go
+++ b/v3/api/store_type_models.go
@@ -39,7 +39,7 @@ type CertificateStoreType struct {
 	Capability          string                         `json:"Capability,omitempty"`
 	StoreType           int                            `json:"StoreType"`
 	ImportType          int                            `json:"ImportType,omitempty"`
-	LocalStore          bool                           `json:"LocalStore,omitempty"`
+	LocalStore          *bool                          `json:"LocalStore,omitempty"`
 	SupportedOperations *StoreTypeSupportedOperations  `json:"SupportedOperations,omitempty"`
 	Properties          *[]StoreTypePropertyDefinition `json:"Properties,omitempty"`
 	EntryParameters     *[]EntryParameter              `json:"EntryParameters,omitempty"`
@@ -48,9 +48,9 @@ type CertificateStoreType struct {
 	StorePathValue      string                         `json:"StorePathValue,omitempty"`
 	PrivateKeyAllowed   string                         `json:"PrivateKeyAllowed,omitempty"`
 	JobProperties       *[]string                      `json:"JobProperties,omitempty"`
-	ServerRequired      bool                           `json:"ServerRequired,omitempty"`
-	PowerShell          bool                           `json:"PowerShell,omitempty"`
-	BlueprintAllowed    bool                           `json:"BlueprintAllowed,omitempty"`
+	ServerRequired      *bool                          `json:"ServerRequired,omitempty"`
+	PowerShell          *bool                          `json:"PowerShell,omitempty"`
+	BlueprintAllowed    *bool                          `json:"BlueprintAllowed,omitempty"`
 	CustomAliasAllowed  string                         `json:"CustomAliasAllowed,omitempty"`
 	ServerRegistration  int                            `json:"ServerRegistration,omitempty"`
 	InventoryEndpoint   string                         `json:"InventoryEndpoint,omitempty"`

--- a/v3/api/template.go
+++ b/v3/api/template.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"strconv"
 )
 
 // GetTemplate takes arguments for a template ID used to facilitate the retrieval
@@ -59,9 +61,12 @@ func (c *Client) GetTemplate(Id interface{}) (*GetTemplateResponse, error) {
 	return jsonResp, err
 }
 
-// GetTemplates asks Keyfactor for a complete list of known certificate templates. A list of
-// GetTemplateResponse structures is returned, containing the template context.
+// GetTemplates asks Keyfactor for a complete list of known certificate templates,
+// paginating automatically so that instances with more than the server's default
+// page size (50) return all templates. A list of GetTemplateResponse structures
+// is returned, containing the template context.
 func (c *Client) GetTemplates() ([]GetTemplateResponse, error) {
+	log.Println("[INFO] Listing certificate templates.")
 
 	// Set Keyfactor-specific headers
 	headers := &apiHeaders{
@@ -71,25 +76,37 @@ func (c *Client) GetTemplates() ([]GetTemplateResponse, error) {
 		},
 	}
 
-	keyfactorAPIStruct := &request{
-		Method:   "GET",
-		Endpoint: "Templates/",
-		Headers:  headers,
-		Query:    nil,
-		Payload:  nil,
-	}
+	const pageSize = 100
+	var all []GetTemplateResponse
+	for page := 1; ; page++ {
+		keyfactorAPIStruct := &request{
+			Method:   "GET",
+			Endpoint: "Templates/",
+			Headers:  headers,
+			Query: &apiQuery{
+				Query: []StringTuple{
+					{"PageReturned", strconv.Itoa(page)},
+					{"ReturnLimit", strconv.Itoa(pageSize)},
+				},
+			},
+			Payload: nil,
+		}
 
-	resp, err := c.sendRequest(keyfactorAPIStruct)
-	if err != nil {
-		return nil, err
-	}
+		resp, err := c.sendRequest(keyfactorAPIStruct)
+		if err != nil {
+			return nil, err
+		}
 
-	var jsonResp []GetTemplateResponse
-	err = json.NewDecoder(resp.Body).Decode(&jsonResp)
-	if err != nil {
-		return nil, err
+		var pageResults []GetTemplateResponse
+		if err = json.NewDecoder(resp.Body).Decode(&pageResults); err != nil {
+			return nil, err
+		}
+		all = append(all, pageResults...)
+		if len(pageResults) < pageSize {
+			break
+		}
 	}
-	return jsonResp, err
+	return all, nil
 }
 
 // UpdateTemplate takes arguments for a UpdateTemplateArg structure used to facilitate the modification

--- a/v3/api/template.go
+++ b/v3/api/template.go
@@ -22,6 +22,11 @@ import (
 	"strconv"
 )
 
+// getTemplatesMaxPages is the maximum number of pages GetTemplates will fetch
+// before aborting with an error. It is an unexported package-level var (not a
+// const) so that tests can lower it without iterating thousands of times.
+var getTemplatesMaxPages = 10000
+
 // GetTemplate takes arguments for a template ID used to facilitate the retrieval
 // of certificate template context. The primary query required to get certificate context is the template ID. A pointer
 // to a GetTemplateResponse structure is returned, containing the template context.
@@ -78,7 +83,8 @@ func (c *Client) GetTemplates() ([]GetTemplateResponse, error) {
 
 	const pageSize = 100
 	var all []GetTemplateResponse
-	for page := 1; ; page++ {
+	var page int
+	for page = 1; page <= getTemplatesMaxPages; page++ {
 		keyfactorAPIStruct := &request{
 			Method:   "GET",
 			Endpoint: "Templates/",
@@ -94,18 +100,29 @@ func (c *Client) GetTemplates() ([]GetTemplateResponse, error) {
 
 		resp, err := c.sendRequest(keyfactorAPIStruct)
 		if err != nil {
+			log.Printf("[ERROR] GetTemplates: request for page %d failed: %s", page, err)
 			return nil, err
 		}
 
 		var pageResults []GetTemplateResponse
-		if err = json.NewDecoder(resp.Body).Decode(&pageResults); err != nil {
-			return nil, err
+		decodeErr := json.NewDecoder(resp.Body).Decode(&pageResults)
+		resp.Body.Close()
+		if decodeErr != nil {
+			log.Printf("[ERROR] GetTemplates: failed to decode page %d: %s", page, decodeErr)
+			return nil, decodeErr
 		}
+
 		all = append(all, pageResults...)
-		if len(pageResults) < pageSize {
+		if len(pageResults) == 0 || len(pageResults) < pageSize {
 			break
 		}
 	}
+
+	if page > getTemplatesMaxPages {
+		return nil, fmt.Errorf("GetTemplates: exceeded max pages (%d); server may be ignoring pagination", getTemplatesMaxPages)
+	}
+
+	log.Printf("[INFO] Listed %d certificate templates across %d page(s).", len(all), page)
 	return all, nil
 }
 

--- a/v3/api/template_test.go
+++ b/v3/api/template_test.go
@@ -75,6 +75,37 @@ func TestGetTemplates_Pagination(t *testing.T) {
 	}
 }
 
+// TestGetTemplates_MaxPagesGuard verifies that GetTemplates aborts with an error
+// when the server always returns a full page (simulating a server that ignores
+// pagination and would otherwise cause an infinite loop / unbounded memory growth).
+func TestGetTemplates_MaxPagesGuard(t *testing.T) {
+	// Build a fixed full page of pageSize (100) items.
+	fullPage := make([]GetTemplateResponse, 100)
+	for i := range fullPage {
+		fullPage[i] = GetTemplateResponse{Id: i + 1, CommonName: "Template-" + strconv.Itoa(i+1)}
+	}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always return a full page regardless of PageReturned — simulates a
+		// server that ignores paging parameters.
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(fullPage)
+	}))
+	defer srv.Close()
+
+	// Lower the safety bound so the test terminates quickly.
+	orig := getTemplatesMaxPages
+	getTemplatesMaxPages = 3
+	defer func() { getTemplatesMaxPages = orig }()
+
+	c := newTestClient(srv)
+
+	_, err := c.GetTemplates()
+	if err == nil {
+		t.Fatal("GetTemplates() expected an error when max pages exceeded, got nil")
+	}
+}
+
 // TestGetTemplates_SinglePage verifies that a sub-pageSize result terminates
 // the pagination loop in a single call.
 func TestGetTemplates_SinglePage(t *testing.T) {

--- a/v3/api/template_test.go
+++ b/v3/api/template_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+// TestGetTemplates_Pagination verifies that GetTemplates fetches all pages.
+// Before the fix, only the first 50 results were returned; a template sorted
+// beyond position 50 (e.g. position 169 out of 278) would never be found by
+// name, causing "Error template name not found" in keyfactor_template_role_binding.
+func TestGetTemplates_Pagination(t *testing.T) {
+	const totalTemplates = 278
+
+	allTemplates := make([]GetTemplateResponse, totalTemplates)
+	for i := range allTemplates {
+		allTemplates[i] = GetTemplateResponse{
+			Id:         i + 1,
+			CommonName: "Template-" + strconv.Itoa(i+1),
+		}
+	}
+	// Place the known-problematic late-sorted template at index 168 (position 169).
+	allTemplates[168] = GetTemplateResponse{Id: 243, CommonName: "zzz-late-sorted-template"}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, _ := strconv.Atoi(r.URL.Query().Get("PageReturned"))
+		limit, _ := strconv.Atoi(r.URL.Query().Get("ReturnLimit"))
+		if page < 1 {
+			page = 1
+		}
+		if limit < 1 {
+			limit = 50
+		}
+		start := (page - 1) * limit
+		end := start + limit
+		if start >= len(allTemplates) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]"))
+			return
+		}
+		if end > len(allTemplates) {
+			end = len(allTemplates)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(allTemplates[start:end])
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+
+	templates, err := c.GetTemplates()
+	if err != nil {
+		t.Fatalf("GetTemplates() error: %v", err)
+	}
+	if len(templates) != totalTemplates {
+		t.Errorf("GetTemplates() returned %d templates, want %d (pagination broken)", len(templates), totalTemplates)
+	}
+
+	// Verify the late-sorted target template is present.
+	found := false
+	for _, tmpl := range templates {
+		if tmpl.CommonName == "zzz-late-sorted-template" {
+			found = true
+			if tmpl.Id != 243 {
+				t.Errorf("target template ID = %d, want 243", tmpl.Id)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("target template %q (position 169) not found — page 2+ results missing", "zzz-late-sorted-template")
+	}
+}
+
+// TestGetTemplates_SinglePage verifies that a sub-pageSize result terminates
+// the pagination loop in a single call.
+func TestGetTemplates_SinglePage(t *testing.T) {
+	calls := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]GetTemplateResponse{{Id: 1, CommonName: "OnlyTemplate"}})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+
+	templates, err := c.GetTemplates()
+	if err != nil {
+		t.Fatalf("GetTemplates() error: %v", err)
+	}
+	if len(templates) != 1 {
+		t.Errorf("got %d templates, want 1", len(templates))
+	}
+	if calls != 1 {
+		t.Errorf("server called %d times, want 1", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Three related fixes for `keyfactor_certificate_store`/`keyfactor_certificate_store_type` support in the Terraform provider (keyfactor-pub/terraform-provider-keyfactor#173), all in the same "can't distinguish unset from explicit zero-value, or missing pagination" bug class:

- `CertificateStoreType.LocalStore`/`ServerRequired`/`PowerShell`/`BlueprintAllowed` changed from `bool` to `*bool` (with `omitempty`) — a plain `bool` can't distinguish "not configured" from "explicitly false," so an explicit `false` set by a Terraform user was indistinguishable from an unconfigured field and silently dropped from outgoing requests.
- `CertificateStore.EntryPassword` gets `omitempty` added — previously always serialized as an explicit `"EntryPassword": null` on every add-certificate-to-store request, even when this resource never sets a password.
- `GetStoreContainers()` now paginates (mirrors the `GetTemplates` pagination fix in #55) — it previously issued a single unparameterized request, silently truncating to Command's default first page. A container sorting beyond page 1 couldn't be resolved by ID via the list-endpoint fallback used when the by-ID lookup fails.

**Depends on #55** (`fix(template): paginate GetTemplates to return all templates`, still open) — this branch is rebased on top of it since both are needed together for the `v3.5.6-rc.2` tag consumed by the provider fix. You'll see #55's two commits in this diff until it merges; the 3 commits that are actually new here are `6e101b3`, `82bbd69`, `bb389f2`.

## Test plan

- [x] New/updated unit tests: `store_type_test.go`-equivalent coverage for the pointer conversion, `store_test.go` for `EntryPassword` omission, `store_container_test.go` (`TestGetStoreContainers_Pagination`, mirroring `TestGetTemplates_Pagination`)
- [x] `go build ./...` clean
- [x] Full package test suite green