### PR TITLE
fix(template): add TemplatePolicy field to Templates request/response models

### DIFF
--- a/v3/api/template_models.go
+++ b/v3/api/template_models.go
@@ -35,6 +35,44 @@ type GetTemplateResponse struct {
 	RFCEnforcement         bool                       `json:"RFCEnforcement,omitempty"`
 	RequiresApproval       bool                       `json:"RequiresApproval,omitempty"`
 	KeyUsage               int                        `json:"KeyUsage,omitempty"`
+	// TemplatePolicy carries the template's key-algorithm policy (PrimaryKeyAlgorithms /
+	// AlternativeKeyAlgorithms, wildcard/key-reuse flags, certificate owner role, etc).
+	// It is null for templates that predate this policy model or have never had it
+	// configured. Command's PUT /Templates full-replace validation derives an internal
+	// "Policies" set from TemplatePolicy.PrimaryKeyAlgorithms/AlternativeKeyAlgorithms;
+	// for templates linked to an enrollment pattern, omitting TemplatePolicy on update
+	// collapses that set to empty and Command rejects the request with
+	// "'Policies' cannot be empty" (confirmed against a live Command 25.4.1 instance).
+	TemplatePolicy *TemplatePolicy `json:"TemplatePolicy,omitempty"`
+}
+
+// TemplateKeyAlgorithm describes one allowed key algorithm entry within a
+// TemplatePolicy's PrimaryKeyAlgorithms/AlternativeKeyAlgorithms list. Field
+// names intentionally match Command's lowercase/snake_case wire format for
+// this nested object (unlike the rest of the Templates API, which is
+// PascalCase).
+type TemplateKeyAlgorithm struct {
+	Name       string   `json:"name,omitempty"`
+	BitLengths []int    `json:"bit_lengths,omitempty"`
+	Curves     []string `json:"curves,omitempty"`
+}
+
+// TemplatePolicy models Command's per-template key/enrollment policy object,
+// returned under GetTemplateResponse.TemplatePolicy and required (when the
+// template has one configured) on UpdateTemplateArg.TemplatePolicy to avoid
+// Command's full-replace PUT /Templates clearing it. See the comment on
+// GetTemplateResponse.TemplatePolicy for the "'Policies' cannot be empty"
+// validation error this addresses.
+type TemplatePolicy struct {
+	TemplateId                      int                    `json:"TemplateId,omitempty"`
+	AllowKeyReuse                   *bool                  `json:"AllowKeyReuse,omitempty"`
+	AllowWildcards                  *bool                  `json:"AllowWildcards,omitempty"`
+	RFCEnforcement                  *bool                  `json:"RFCEnforcement,omitempty"`
+	CertificateOwnerRole            *int                   `json:"CertificateOwnerRole,omitempty"`
+	DefaultCertificateOwnerRoleId   *int                   `json:"DefaultCertificateOwnerRoleId,omitempty"`
+	DefaultCertificateOwnerRoleName *string                `json:"DefaultCertificateOwnerRoleName,omitempty"`
+	PrimaryKeyAlgorithms            []TemplateKeyAlgorithm `json:"PrimaryKeyAlgorithms,omitempty"`
+	AlternativeKeyAlgorithms        []TemplateKeyAlgorithm `json:"AlternativeKeyAlgorithms,omitempty"`
 }
 
 type TemplateEnrollmentFields struct {
@@ -82,6 +120,9 @@ type UpdateTemplateArg struct {
 	RFCEnforcement         *bool                       `json:"RFCEnforcement,omitempty"`
 	RequiresApproval       *bool                       `json:"RequiresApproval,omitempty"`
 	KeyUsage               *bool                       `json:"KeyUsage,omitempty"`
+	// TemplatePolicy must be round-tripped from the corresponding GetTemplateResponse
+	// on every update; see the field comment on GetTemplateResponse.TemplatePolicy.
+	TemplatePolicy *TemplatePolicy `json:"TemplatePolicy,omitempty"`
 }
 
 type UpdateTemplateResponse struct{ GetTemplateResponse }

--- a/v3/api/template_test.go
+++ b/v3/api/template_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -128,5 +129,118 @@ func TestGetTemplates_SinglePage(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("server called %d times, want 1", calls)
+	}
+}
+
+// TestGetTemplateResponse_TemplatePolicy_Decode verifies that GetTemplateResponse
+// decodes the "TemplatePolicy" object Command returns for templates linked to an
+// enrollment pattern (PrimaryKeyAlgorithms/AlternativeKeyAlgorithms, wildcard/key-reuse
+// flags, etc). Before the fix GetTemplateResponse had no TemplatePolicy field at all,
+// so encoding/json silently dropped it and buildTemplateRoleBindingUpdateArg-style
+// callers had nothing to copy forward.
+func TestGetTemplateResponse_TemplatePolicy_Decode(t *testing.T) {
+	// Trimmed down, real shape captured from a live Command 25.4.1 GET /Templates/{id}
+	// response for a template linked to an enrollment pattern.
+	body := `{
+		"Id": 4,
+		"CommonName": "Server_tlsServerAuth-1y",
+		"UseAllowedRequesters": true,
+		"AllowedRequesters": ["Administrator", "InstanceOwner"],
+		"TemplatePolicy": {
+			"TemplateId": 4,
+			"AllowKeyReuse": true,
+			"AllowWildcards": true,
+			"RFCEnforcement": null,
+			"CertificateOwnerRole": 0,
+			"PrimaryKeyAlgorithms": [
+				{"name": "RSA", "bit_lengths": [2048, 3072, 4096], "curves": []},
+				{"name": "Ed25519", "bit_lengths": [255], "curves": []}
+			],
+			"AlternativeKeyAlgorithms": []
+		}
+	}`
+
+	var resp GetTemplateResponse
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error: %v", err)
+	}
+
+	if resp.TemplatePolicy == nil {
+		t.Fatal("GetTemplateResponse.TemplatePolicy = nil, want non-nil (field not decoded)")
+	}
+	if got, want := len(resp.TemplatePolicy.PrimaryKeyAlgorithms), 2; got != want {
+		t.Fatalf("len(TemplatePolicy.PrimaryKeyAlgorithms) = %d, want %d", got, want)
+	}
+	if got, want := resp.TemplatePolicy.PrimaryKeyAlgorithms[0].Name, "RSA"; got != want {
+		t.Errorf("PrimaryKeyAlgorithms[0].Name = %q, want %q", got, want)
+	}
+	if got, want := resp.TemplatePolicy.PrimaryKeyAlgorithms[0].BitLengths, []int{2048, 3072, 4096}; len(got) != len(want) {
+		t.Errorf("PrimaryKeyAlgorithms[0].BitLengths = %v, want %v", got, want)
+	}
+	if resp.TemplatePolicy.AllowKeyReuse == nil || !*resp.TemplatePolicy.AllowKeyReuse {
+		t.Errorf("TemplatePolicy.AllowKeyReuse = %v, want true", resp.TemplatePolicy.AllowKeyReuse)
+	}
+}
+
+// TestUpdateTemplateArg_TemplatePolicy_Roundtrip verifies that an UpdateTemplateArg
+// with TemplatePolicy set actually serializes that field onto the wire when passed to
+// UpdateTemplate. This is the crux of the "'Policies' cannot be empty" bug fix
+// (Keyfactor/terraform-provider-keyfactor#180): Command's PUT /Templates rejects the
+// full-replace update outright for templates linked to an enrollment pattern unless
+// TemplatePolicy.PrimaryKeyAlgorithms/AlternativeKeyAlgorithms round-trip the
+// previously-fetched values. Before the fix, UpdateTemplateArg had no TemplatePolicy
+// field, so this could never be sent — this test would fail to compile against the
+// pre-fix struct definition.
+func TestUpdateTemplateArg_TemplatePolicy_Roundtrip(t *testing.T) {
+	var receivedBody []byte
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(receivedBody)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+
+	allowKeyReuse := true
+	allowWildcards := true
+	useAllowedRequesters := true
+	allowedRequesters := []string{"Administrator", "InstanceOwner"}
+	arg := &UpdateTemplateArg{
+		Id:                   4,
+		UseAllowedRequesters: &useAllowedRequesters,
+		AllowedRequesters:    &allowedRequesters,
+		TemplatePolicy: &TemplatePolicy{
+			TemplateId:     4,
+			AllowKeyReuse:  &allowKeyReuse,
+			AllowWildcards: &allowWildcards,
+			PrimaryKeyAlgorithms: []TemplateKeyAlgorithm{
+				{Name: "RSA", BitLengths: []int{2048, 3072, 4096}},
+				{Name: "Ed25519", BitLengths: []int{255}},
+			},
+		},
+	}
+
+	if _, err := c.UpdateTemplate(arg); err != nil {
+		t.Fatalf("UpdateTemplate() error: %v", err)
+	}
+
+	var onWire map[string]interface{}
+	if err := json.Unmarshal(receivedBody, &onWire); err != nil {
+		t.Fatalf("failed to decode request body sent to server: %v", err)
+	}
+
+	policy, ok := onWire["TemplatePolicy"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("request body sent to server has no TemplatePolicy object; got keys: %v", onWire)
+	}
+	primaryAlgos, ok := policy["PrimaryKeyAlgorithms"].([]interface{})
+	if !ok || len(primaryAlgos) != 2 {
+		t.Fatalf("TemplatePolicy.PrimaryKeyAlgorithms on the wire = %v, want 2 entries", policy["PrimaryKeyAlgorithms"])
 	}
 }


### PR DESCRIPTION
## Summary

Fixes keyfactor-pub/terraform-provider-keyfactor#180. `GetTemplateResponse` and `UpdateTemplateArg` had no field modeling Command's per-template `TemplatePolicy` object (`PrimaryKeyAlgorithms`, `AlternativeKeyAlgorithms`, `AllowKeyReuse`, `AllowWildcards`, etc). Since `UpdateTemplate`'s `PUT /Templates` is a full-replace endpoint, omitting this field on update silently drops it — and for any template linked to an enrollment pattern, Command's server-side validation then rejects the request outright with `'Policies' cannot be empty`, since the internal policy set it derives from `TemplatePolicy` collapses to empty.

Confirmed against a live Command 25.4.1 instance: a `PUT /Templates` payload identical to what callers previously sent (no `TemplatePolicy`) reproduces the error on any enrollment-pattern-linked template; round-tripping the `TemplatePolicy` value from the prior `GetTemplateResponse` succeeds.

## Changes

- Adds `TemplateKeyAlgorithm` and `TemplatePolicy` structs to `v3/api/template_models.go`
- Wires `TemplatePolicy` into `GetTemplateResponse.TemplatePolicy` (decode) and `UpdateTemplateArg.TemplatePolicy` (update-serialization)

## Test plan

- [x] `TestGetTemplateResponse_TemplatePolicy_Decode` and `TestUpdateTemplateArg_TemplatePolicy_Roundtrip` — new regression tests covering both the decode and update paths
- [x] Red→green: confirmed `go vet` fails with `TemplatePolicy undefined` against the pre-fix model, passes after
- [x] `GOWORK=off go build ./...` clean, `GOWORK=off go test ./...` full suite green
- [x] Verified live against Command 25.4.1: reproduced the exact `'Policies' cannot be empty` error with the old payload shape, confirmed `HTTP 200` with `TemplatePolicy` round-tripped from `GET /Templates`