### PR TITLE
fix(template): change UpdateTemplateArg.KeyUsage to *int to match Command API

### DIFF
--- a/v2/api/template_models.go
+++ b/v2/api/template_models.go
@@ -81,7 +81,13 @@ type UpdateTemplateArg struct {
 	AllowedRequesters      *[]string                   `json:"AllowedRequesters,omitempty"`
 	RFCEnforcement         *bool                       `json:"RFCEnforcement,omitempty"`
 	RequiresApproval       *bool                       `json:"RequiresApproval,omitempty"`
-	KeyUsage               *bool                       `json:"KeyUsage,omitempty"`
+	// KeyUsage is an int32 bitmask on Command's wire format (e.g. 160 =
+	// digitalSignature|keyEncipherment), matching GetTemplateResponse.KeyUsage and
+	// Command's TemplateUpdateRequest/TemplateRetrievalResponse swagger schema
+	// (both typed "integer"/"int32"). A *bool here previously produced a live
+	// HTTP 400 ("Unexpected character encountered while parsing value: t. Path
+	// 'KeyUsage'") since Command rejects a JSON boolean for an integer field.
+	KeyUsage *int `json:"KeyUsage,omitempty"`
 }
 
 type UpdateTemplateResponse struct{ GetTemplateResponse }

--- a/v3/api/template_models.go
+++ b/v3/api/template_models.go
@@ -119,7 +119,13 @@ type UpdateTemplateArg struct {
 	AllowedRequesters      *[]string                   `json:"AllowedRequesters,omitempty"`
 	RFCEnforcement         *bool                       `json:"RFCEnforcement,omitempty"`
 	RequiresApproval       *bool                       `json:"RequiresApproval,omitempty"`
-	KeyUsage               *bool                       `json:"KeyUsage,omitempty"`
+	// KeyUsage is an int32 bitmask on Command's wire format (e.g. 160 =
+	// digitalSignature|keyEncipherment), matching GetTemplateResponse.KeyUsage and
+	// Command's TemplateUpdateRequest/TemplateRetrievalResponse swagger schema
+	// (both typed "integer"/"int32"). A *bool here previously produced a live
+	// HTTP 400 ("Unexpected character encountered while parsing value: t. Path
+	// 'KeyUsage'") since Command rejects a JSON boolean for an integer field.
+	KeyUsage *int `json:"KeyUsage,omitempty"`
 	// TemplatePolicy must be round-tripped from the corresponding GetTemplateResponse
 	// on every update; see the field comment on GetTemplateResponse.TemplatePolicy.
 	TemplatePolicy *TemplatePolicy `json:"TemplatePolicy,omitempty"`

--- a/v3/api/template_test.go
+++ b/v3/api/template_test.go
@@ -244,3 +244,62 @@ func TestUpdateTemplateArg_TemplatePolicy_Roundtrip(t *testing.T) {
 		t.Fatalf("TemplatePolicy.PrimaryKeyAlgorithms on the wire = %v, want 2 entries", policy["PrimaryKeyAlgorithms"])
 	}
 }
+
+// TestUpdateTemplateArg_KeyUsage_SerializesAsInt verifies that UpdateTemplateArg.KeyUsage
+// serializes onto the wire as a JSON number, matching Command's TemplateUpdateRequest
+// swagger schema ({"type":"integer","format":"int32"}) confirmed against a live v25.5
+// instance. Before the fix, KeyUsage was typed *bool, which serialized as a JSON boolean
+// and produced a live HTTP 400 from Command ("Unexpected character encountered while
+// parsing value: t. Path 'KeyUsage'"). This also verifies the value returned by
+// GetTemplateResponse.KeyUsage (an int) can be assigned directly to
+// UpdateTemplateArg.KeyUsage without a type conversion, since both now agree on int.
+func TestUpdateTemplateArg_KeyUsage_SerializesAsInt(t *testing.T) {
+	var receivedBody []byte
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(receivedBody)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+
+	// Simulate a real read-modify-write: KeyUsage comes straight off a
+	// GetTemplateResponse (int) with no bool<->int conversion required.
+	fetched := GetTemplateResponse{Id: 4, KeyUsage: 160} // digitalSignature|keyEncipherment
+	keyUsage := fetched.KeyUsage
+
+	arg := &UpdateTemplateArg{
+		Id:       4,
+		KeyUsage: &keyUsage,
+	}
+
+	if _, err := c.UpdateTemplate(arg); err != nil {
+		t.Fatalf("UpdateTemplate() error: %v", err)
+	}
+
+	var onWire map[string]interface{}
+	if err := json.Unmarshal(receivedBody, &onWire); err != nil {
+		t.Fatalf("failed to decode request body sent to server: %v", err)
+	}
+
+	rawKeyUsage, ok := onWire["KeyUsage"]
+	if !ok {
+		t.Fatalf("request body sent to server has no KeyUsage field; got keys: %v", onWire)
+	}
+	switch v := rawKeyUsage.(type) {
+	case float64:
+		if v != 160 {
+			t.Errorf("KeyUsage on the wire = %v, want 160", v)
+		}
+	case bool:
+		t.Fatalf("KeyUsage on the wire is a JSON boolean (%v); Command's API expects an int32 bitmask and returns HTTP 400 for a boolean payload", v)
+	default:
+		t.Fatalf("KeyUsage on the wire has unexpected type %T (value %v), want a JSON number", v, v)
+	}
+}


### PR DESCRIPTION
## Summary

`UpdateTemplateArg.KeyUsage` is currently typed `*bool` in both `v3/api/template_models.go` and `v2/api/template_models.go`. Command's live API disagrees:

- `TemplateUpdateRequest.KeyUsage` and `TemplateRetrievalResponse.KeyUsage` are both `{"type":"integer","format":"int32"}` per the v25.5 swagger — an int32 bitmask (e.g. `160` = `digitalSignature|keyEncipherment`).
- `GetTemplateResponse.KeyUsage` in this repo is already typed `int`, so the get/update models disagree with each other on top of disagreeing with the server.
- Sending a bool payload against a live v25.5 Command instance produces an HTTP 400: `Unexpected character encountered while parsing value: t. Path 'KeyUsage'`.

This makes the field unusable as-is for any caller trying to round-trip `KeyUsage` through a template update.

## Change

- `v3/api/template_models.go`: `UpdateTemplateArg.KeyUsage` `*bool` → `*int`.
- `v2/api/template_models.go`: same fix, for consistency (v2 is tagged/released independently of v3 and is not part of the v3.6.0 target for this change).
- `v3/api/template_test.go`: adds `TestUpdateTemplateArg_KeyUsage_SerializesAsInt`, which fails to compile against the pre-fix `*bool` field and asserts the JSON payload sent to Command is a number, not a boolean.

This is a breaking type change, but the field was non-functional beforehand (any real use hit the 400 above), so there's no working caller to break. Targeted for v3.6.0.

## Test plan
- [x] `GOWORK=off go build ./...` (v3 module)
- [x] `GOWORK=off go vet ./...` (v3 module)
- [x] `GOWORK=off go test ./...` (v3 module) — full suite passes, including the new regression test
- [x] `GOWORK=off go build ./...` (v2 module) — builds clean (pre-existing, unrelated `go vet` failure in `v2/api/client_test.go` confirmed present before this change too, via `git stash`)